### PR TITLE
:bug: [FIX] 순환참조 문제 해결 및 구조 개선, OAuth URI 변경 #47

### DIFF
--- a/src/main/java/swm_nm/morandi/auth/constants/OAuthConstants.java
+++ b/src/main/java/swm_nm/morandi/auth/constants/OAuthConstants.java
@@ -13,7 +13,7 @@ public class OAuthConstants {
             + "include_granted_scopes=true&"
             + "response_type=code&"
             + "state=state_parameter_passthrough_value&"
-            +"redirect_uri=http://localhost:8080/users/google/callback&"
+            +"redirect_uri=http://localhost:8080/oauths/google/callback&"
             +"client_id=1047762864117-c4i1inqqugoesvruk7gkjv0itdnm9mov.apps.googleusercontent.com";
     public static final String GOOGLE_BASE_URL = "https://accounts.google.com/o/oauth2/v2/auth?";
     public static final String GOOGLE_SCOPE = "scope=https://www.googleapis.com/auth/userinfo.email&";

--- a/src/main/java/swm_nm/morandi/auth/controller/OAuthController.java
+++ b/src/main/java/swm_nm/morandi/auth/controller/OAuthController.java
@@ -8,14 +8,14 @@ import swm_nm.morandi.auth.service.LoginService;
 
 
 @RestController
-@RequestMapping("users")
+@RequestMapping("/oauths")
 @RequiredArgsConstructor
 public class OAuthController {
 
 
     private final LoginService loginService;
 
-    //개발 테스트용
+    //Authorization Code도 모두 가져오는 경우에 사용하는 callback api
     @GetMapping("/{type}/callback")
     public TokenDto googleLogin(@PathVariable String type, @RequestParam String code) {
         return loginService.login(type, code);
@@ -23,10 +23,10 @@ public class OAuthController {
 
     }
 
-    //실제로 사용할 용도
-    @GetMapping("/login/{type}")
-    public TokenDto login(@PathVariable String type, @RequestParam String code) {
-        return loginService.OAuthJoinOrLogin(type, code);
+    //만약 이미 access Toekn을 가지고 있는 경우에는 이 api를 사용한다.
+    @GetMapping("/{type}/login")
+    public TokenDto login(@PathVariable String type, @RequestParam String accessToken) {
+        return loginService.OAuthJoinOrLogin(type, accessToken);
     }
 
 

--- a/src/main/java/swm_nm/morandi/auth/controller/OAuthURIController.java
+++ b/src/main/java/swm_nm/morandi/auth/controller/OAuthURIController.java
@@ -9,7 +9,7 @@ import swm_nm.morandi.auth.constants.OAuthConstants;
 
 @Controller
 @PropertySource("classpath:application-oauth.properties")
-@RequestMapping("/users")
+@RequestMapping("/oauths")
 public class OAuthURIController {
 
     @Value("${oauth.google.client-id}")
@@ -18,7 +18,7 @@ public class OAuthURIController {
     @Value("${oauth.google.redirect-uri}")
     private String google_redirect_uri;
 
-    @GetMapping("/google/redirect")
+    @GetMapping("/google")
     public String googleRedirect() {
 
         //이것도 service로 빼기

--- a/src/main/java/swm_nm/morandi/auth/security/SecurityConfig.java
+++ b/src/main/java/swm_nm/morandi/auth/security/SecurityConfig.java
@@ -24,15 +24,11 @@ public class SecurityConfig {
      http
                 .httpBasic().disable()
                 .csrf().disable()
-
-//                .exceptionHandling()
-//                .authenticationEntryPoint(jwtAuthException)
-             //   .and()
                 .cors()
                 .and()
 
                 .authorizeRequests()
-                .antMatchers("/users/**").permitAll()
+                .antMatchers("/oauths/**").permitAll()
                 .anyRequest().authenticated()
                 .and()
 

--- a/src/main/java/swm_nm/morandi/auth/service/LoginService.java
+++ b/src/main/java/swm_nm/morandi/auth/service/LoginService.java
@@ -26,18 +26,18 @@ public class LoginService {
 
         GoogleUserDto googleUserDto = oAuthService.getMemberInfo(accessToken);
 
-        return memberService.registerMember(googleUserDto);
+        return memberService.loginOrRegisterMember(googleUserDto);
 
 
     }
     public TokenDto OAuthJoinOrLogin(String type, String accessToken){
         OAuthService oAuthService = oAuthServiceFactory.getServiceByType(type);
         if (oAuthService == null) {
-            throw new IllegalArgumentException("지원되지 않는 OAuth provider 입니다 : " + type);
+            throw new MorandiException(AuthErrorCode.INVALID_SOCIAL_TYPE);
         }
         GoogleUserDto googleUserDto = oAuthService.getMemberInfo(accessToken);
         
-        return memberService.registerMember(googleUserDto);
+        return memberService.loginOrRegisterMember(googleUserDto);
 
 
     }

--- a/src/main/java/swm_nm/morandi/exception/errorcode/ProblemErrorCode.java
+++ b/src/main/java/swm_nm/morandi/exception/errorcode/ProblemErrorCode.java
@@ -1,0 +1,16 @@
+package swm_nm.morandi.exception.errorcode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+@Getter
+public enum ProblemErrorCode implements ErrorCode {
+    PROBLEM_NOT_FOUND(HttpStatus.NOT_FOUND, "문제를 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+
+}

--- a/src/main/java/swm_nm/morandi/exception/errorcode/TestErrorCode.java
+++ b/src/main/java/swm_nm/morandi/exception/errorcode/TestErrorCode.java
@@ -1,0 +1,16 @@
+package swm_nm.morandi.exception.errorcode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+@Getter
+public enum TestErrorCode implements ErrorCode {
+    TEST_NOT_FOUND(HttpStatus.NOT_FOUND, "테스트를 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+
+}

--- a/src/main/java/swm_nm/morandi/exception/errorcode/TestTypeErrorCode.java
+++ b/src/main/java/swm_nm/morandi/exception/errorcode/TestTypeErrorCode.java
@@ -1,0 +1,16 @@
+package swm_nm.morandi.exception.errorcode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+@Getter
+public enum TestTypeErrorCode implements ErrorCode {
+    TEST_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "테스트 타입을 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+
+}

--- a/src/main/java/swm_nm/morandi/member/repository/AttemptProblemRepository.java
+++ b/src/main/java/swm_nm/morandi/member/repository/AttemptProblemRepository.java
@@ -8,9 +8,9 @@ import java.util.List;
 import java.util.Optional;
 
 public interface AttemptProblemRepository extends JpaRepository<AttemptProblem, Long> {
-    Optional<List<AttemptProblem>> findAllByMember_MemberId(Long memberId);
-    Optional<List<AttemptProblem>> findAllByTest_TestId(Long testId);
-    Optional<List<AttemptProblem>> findAttemptProblemsByTest_TestId(Long testId);
+    List<AttemptProblem> findAllByMember_MemberId(Long memberId);
+    List<AttemptProblem> findAllByTest_TestId(Long testId);
+    List<AttemptProblem> findAttemptProblemsByTest_TestId(Long testId);
 }
 
 

--- a/src/main/java/swm_nm/morandi/member/service/MemberService.java
+++ b/src/main/java/swm_nm/morandi/member/service/MemberService.java
@@ -38,34 +38,20 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final JwtProvider jwtProvider;
-    public TokenDto registerMember(GoogleUserDto googleUserDto){
-    //TODO
-        //이부분에 oidc 검증로직 넣기
+    public TokenDto loginOrRegisterMember(GoogleUserDto googleUserDto){
+        Member member = memberRepository.findByEmail(googleUserDto.getEmail())
+                .orElseGet(() -> memberRepository.save(
+                                Member.builder()
+                                        .email(googleUserDto.getEmail())
+                                        .nickname(googleUserDto.getName())
+                                        .thumbPhoto(googleUserDto.getPicture())
+                                        .socialInfo(googleUserDto.getType())
+                                        .rating(1000L)
+                                        .build()
+                        )
+                );
 
-
-
-
-
-        // 이메일이나 아이디가 이미 존재하는지 검증하는 로직도 넣기
-        Optional<Member> findMember = memberRepository.findByEmail(googleUserDto.getEmail());
-        // 이메일이나 아이디가 존재하지 않으면 회원가입 진행
-        if(findMember.isEmpty()) {
-            findMember = Optional.of(Member.builder()
-                    .email(googleUserDto.getEmail())
-                    .nickname(googleUserDto.getName())
-                    .thumbPhoto(googleUserDto.getPicture())
-                    .socialInfo(googleUserDto.getType())
-                    .rating(1000L)
-                    .build());
-            memberRepository.save(findMember.get());
-            TokenDto tokenDto = jwtProvider.getTokens(findMember.get());
-            return tokenDto;
-        }
-        //토큰 발급 로직 넣기
-        TokenDto tokenDto = jwtProvider.getTokens(findMember.get());
-
-        return tokenDto;
-
+        return jwtProvider.getTokens(member);
     }
     private String userHome = System.getProperty("user.home");
     private String uploadFolder = userHome + "/SWM/morandi-backend/morandi-backend/uploads";

--- a/src/main/java/swm_nm/morandi/problem/dataloader/DataLoader.java
+++ b/src/main/java/swm_nm/morandi/problem/dataloader/DataLoader.java
@@ -149,7 +149,7 @@ public class DataLoader implements CommandLineRunner {
             AttemptProblem attemptProblem = AttemptProblem.builder()
                     .isSolved(true)
                     .testDate(LocalDate.now())
-                    .solvedTime(10)
+                    .executionTime(10L)
                     .member(null)
                     .test(test)
                     .problem(problem)

--- a/src/main/java/swm_nm/morandi/test/controller/TestController.java
+++ b/src/main/java/swm_nm/morandi/test/controller/TestController.java
@@ -41,6 +41,8 @@ public class TestController {
         return new ResponseEntity<>(testTypeService.getTestTypeDto(testTypeId), HttpStatus.OK);
     }
 
+
+    //DTO사용해서 반환하게 바꾸자 나중에는
     @PostMapping("/tests")
     public ResponseEntity<Map<String, Object>> testStart
             (@RequestBody Map<String, Long> testTypeMap) throws JsonProcessingException {

--- a/src/main/java/swm_nm/morandi/testResult/service/TestResultService.java
+++ b/src/main/java/swm_nm/morandi/testResult/service/TestResultService.java
@@ -1,13 +1,24 @@
 package swm_nm.morandi.testResult.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
 import swm_nm.morandi.auth.security.SecurityUtils;
+import swm_nm.morandi.exception.MorandiException;
+import swm_nm.morandi.exception.errorcode.AuthErrorCode;
+import swm_nm.morandi.exception.errorcode.MemberErrorCode;
+import swm_nm.morandi.exception.errorcode.ProblemErrorCode;
+import swm_nm.morandi.exception.errorcode.TestErrorCode;
 import swm_nm.morandi.member.domain.Member;
 import swm_nm.morandi.member.repository.AttemptProblemRepository;
 import swm_nm.morandi.member.repository.MemberRepository;
 import swm_nm.morandi.problem.domain.Problem;
+import swm_nm.morandi.problem.dto.BojProblem;
 import swm_nm.morandi.problem.dto.DifficultyLevel;
+import swm_nm.morandi.problem.repository.ProblemRepository;
 import swm_nm.morandi.test.domain.Test;
 import swm_nm.morandi.test.domain.TestType;
 import swm_nm.morandi.test.dto.TestCheckDto;
@@ -16,12 +27,14 @@ import swm_nm.morandi.test.repository.TestRepository;
 import swm_nm.morandi.test.repository.TestTypeRepository;
 import swm_nm.morandi.testResult.entity.AttemptProblem;
 import swm_nm.morandi.testResult.request.AttemptProblemDto;
-import swm_nm.morandi.testResult.request.TestResultDto;
 
 import javax.transaction.Transactional;
+import java.net.URI;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import static java.lang.Math.max;
 
@@ -34,18 +47,49 @@ public class TestResultService {
 
     private final TestRepository testRepository;
 
-    private final AttemptProblemService attemptProblemService;
 
     private final AttemptProblemRepository attemptProblemRepository;
 
+    private final ProblemRepository problemRepository;
+
+    private final ObjectMapper objectMapper;
+
     @Transactional
+    public List<Long> saveAttemptProblems(Long memberId, Long testId, List<BojProblem> bojProblems) {
+        Member member = memberRepository.findById(memberId).orElseThrow(() -> new MorandiException(MemberErrorCode.MEMBER_NOT_FOUND));
+        Test test = testRepository.findById(testId).orElseThrow(()-> new MorandiException(TestErrorCode.TEST_NOT_FOUND));
+        List<Long> attemptProblemIds = new ArrayList<>();
+        for (BojProblem bojProblem : bojProblems) {
+            Problem problem = problemRepository.findProblemByBojProblemId(bojProblem.getBojProblemId())
+                    .orElseThrow(()-> new MorandiException(ProblemErrorCode.PROBLEM_NOT_FOUND));
+
+            AttemptProblem attemptProblem = AttemptProblem.builder()
+                    .isSolved(false)
+                    .testDate(LocalDate.now())
+                    .executionTime(null)
+                    .member(member)
+                    .test(test)
+                    .problem(problem)
+                    .build();
+            attemptProblemRepository.save(attemptProblem);
+            attemptProblemIds.add(attemptProblem.getAttemptProblemId());
+        }
+        return attemptProblemIds;
+    }
+
+    //TODO
+    //정답률, 테스트 레이팅 계산 시
+    //굳이 맞춘 문제 개수를 다시 DB에서 읽어와서 계산할 필요가 있을까?
+    //한 메서드를 진행하는데 같은 데이터를 DB에서 여러 번 읽어오는 것이 비효율적임
+
+
     public void saveTestResult(Long testId, Long testTypeId){
         Long memberId = SecurityUtils.getCurrentMemberId();
-        Member member = memberRepository.findById(memberId).orElseThrow(()-> new RuntimeException("사용자를 찾을 수 없습니다."));
+        Member member = memberRepository.findById(memberId).orElseThrow(()-> new MorandiException(AuthErrorCode.MEMBER_NOT_FOUND));
         Test test = testRepository.findById(testId).orElseThrow(() -> new RuntimeException("테스트를 찾을 수 없습니다."));
         TestType testType = testTypeRepository.findById(testTypeId).orElseThrow(() -> new RuntimeException("테스트 유형을 찾을 수 없습니다."));
         test.setTestStatus(TestStatus.COMPLETED);
-        List<AttemptProblem> attemptProblems = new ArrayList<>();
+        List<AttemptProblem> attemptProblems = attemptProblemRepository.findAllByTest_TestId(testId);
         long correct = attemptProblems.stream()
                 .filter(AttemptProblem::getIsSolved)
                 .count();
@@ -57,16 +101,62 @@ public class TestResultService {
         //테스트 레이팅 저장
         test.setTestRating(calculateTestRating(member, testId));
     }
+
+    private boolean isSolvedProblem(AttemptProblem attemptProblem, String bojId) {
+        Problem problem = attemptProblem.getProblem();
+        Long bojProblemId = problem.getBojProblemId();
+        String apiURL = "https://solved.ac/api/v3/search/problem";
+        String query = apiURL + "/?query=" + "id:" + bojProblemId.toString() + "%26@" + bojId;
+
+        URI uri = URI.create(query);
+
+        WebClient webClient = WebClient.builder().build();
+        String jsonString = webClient.get()
+                .uri(uri)
+                .retrieve()
+                .bodyToMono(String.class)
+                .block();
+        try {
+            JsonNode jsonNode = objectMapper.readTree(jsonString);
+            JsonNode checkNode = jsonNode.get("count");
+            return checkNode.asLong()==1L;
+
+        }
+        catch(NullPointerException e){
+            throw new RuntimeException("Node null 반환했습니다.");
+        }
+        catch (JsonProcessingException e) {
+            throw new RuntimeException("json 파싱에 실패했습니다.");
+        }
+
+
+    }
+    @Transactional
+    public void checkAttemptedProblemResult(Long testId, String bojId) {
+        Test test = testRepository.findById(testId).orElseThrow(() -> new MorandiException(TestErrorCode.TEST_NOT_FOUND));
+        List<AttemptProblem> attemptProblems = attemptProblemRepository.findAttemptProblemsByTest_TestId(testId);
+
+        attemptProblems.stream()
+                .filter(attemptProblem -> !attemptProblem.getIsSolved())
+                .filter(attemptProblem -> isSolvedProblem(attemptProblem,bojId))
+                .forEach(attemptProblem -> {
+                    Duration duration = Duration.between(test.getTestDate(), LocalDateTime.now());
+                    Long minutes = duration.toMinutes();
+                    attemptProblem.setIsSolved(true);
+                    attemptProblem.setExecutionTime(minutes);
+                });
+    }
+    @Transactional
     public List<AttemptProblemDto> testExit(TestCheckDto testCheckDto) {
         Long testId = testCheckDto.getTestId();
         String bojId = testCheckDto.getBojId();
         Long testTypeId = testCheckDto.getTestTypeId();
-        attemptProblemService.checkAttemptedProblemResult(testId, bojId);
+
+        checkAttemptedProblemResult(testId, bojId);
         saveTestResult(testId, testTypeId);
-        Optional<Test> resultTest = testRepository.findById(testId);
-        Optional<List<AttemptProblem>> resultAttemptProblems = attemptProblemRepository.findAttemptProblemsByTest_TestId(testId);
-        Test test = resultTest.get();
-        List<AttemptProblem> attemptProblems = resultAttemptProblems.get();
+
+        List<AttemptProblem> attemptProblems = attemptProblemRepository.findAttemptProblemsByTest_TestId(testId);
+
         List<AttemptProblemDto> attemptProblemDtos = new ArrayList<>();
         long number = 1;
         for (AttemptProblem attemptProblem : attemptProblems) {
@@ -80,9 +170,8 @@ public class TestResultService {
     public List<AttemptProblemDto> isSolvedCheck(TestCheckDto testCheckDto) {
         Long testId = testCheckDto.getTestId();
         String bojId = testCheckDto.getBojId();
-        attemptProblemService.checkAttemptedProblemResult(testId, bojId);
-        Optional<List<AttemptProblem>> resultAttemptProblems = attemptProblemRepository.findAttemptProblemsByTest_TestId(testId);
-        List<AttemptProblem> attemptProblems = resultAttemptProblems.get();
+        checkAttemptedProblemResult(testId, bojId);
+        List<AttemptProblem> attemptProblems = attemptProblemRepository.findAttemptProblemsByTest_TestId(testId);
         List<AttemptProblemDto> attemptProblemDtos = new ArrayList<>();
         long number = 1;
         for (AttemptProblem attemptProblem : attemptProblems) {
@@ -95,15 +184,13 @@ public class TestResultService {
 
     @Transactional
     public Long calculateTestRating(Member member, Long testId) {
-        Optional<List<AttemptProblem>> resAttemptProblems
+        List<AttemptProblem> attemptProblems
                 = attemptProblemRepository.findAttemptProblemsByTest_TestId(testId);
 
         Long memberRating = member.getRating();
         long rating = 0L;
         boolean allSolved = true;
-        if (resAttemptProblems.isPresent()) {
-
-            List<AttemptProblem> attemptProblems = resAttemptProblems.get();
+        if (!attemptProblems.isEmpty()) {
 
 
             System.out.println("attemptProblems.size() = " + attemptProblems.size());


### PR DESCRIPTION
순환참조 문제 해결 및 구조 개선, OAuth URI 변경
//TODO
    //정답률, 테스트 레이팅 계산 시
    //굳이 맞춘 문제 개수를 다시 DB에서 읽어와서 계산할 필요가 있을까?
    //한 메서드를 진행하는데 같은 데이터를 DB에서 여러 번 읽어오는 것이 비효율적임