### PR TITLE
[REFACTOR] 코드 조회 및 저장 API 수정

### DIFF
--- a/src/main/java/swm_nm/morandi/domain/testDuring/controller/TestDuringController.java
+++ b/src/main/java/swm_nm/morandi/domain/testDuring/controller/TestDuringController.java
@@ -25,8 +25,6 @@ public class TestDuringController {
 
     private final SolvedCheckService solvedCheckService;
 
-    private final TempCodeService tempCodeService;
-
     @PostMapping("/output")
     @Operation(summary = "코드 실행 결과값 반환", description = "사용자가 특정 코드를 실행할 경우 결과값을 제공합니다.")
     public ResponseEntity<OutputDto> getOutputResult
@@ -44,25 +42,5 @@ public class TestDuringController {
     public ResponseEntity<List<AttemptProblemDto>> checkAttemptedProblemResult
             (@RequestBody TestCheckDto testCheckDto) {
         return new ResponseEntity<>(solvedCheckService.isSolvedCheck(testCheckDto), HttpStatus.OK);
-    }
-
-    @PostMapping("/code")
-    @Operation(summary = "테스트 중인 코드를 저장합니다", description = "테스트 중인 코드를 저장\n" +
-            "testId와 attemptProblemId를 통해 테스트 중인 코드를 지속적으로 저장함\n")
-    public void saveTempCode(@RequestBody TempCodeDto tempCodeDto) {
-        tempCodeService.saveTempCode(tempCodeDto);
-    }
-
-    @GetMapping("/code")
-    @Operation(summary = "저장된 코드를 확인합니다", description = "테스트 중일 때, 문제 번호를 바꿀 때 코드 정보를\n" +
-            "testId와 attemptProblemId를 이용하여 가져온다. \n")
-    public ResponseEntity<TempCode> getTempCode(@RequestParam String testId,
-                                                @RequestParam String problemNumber,
-                                                @RequestParam String language) {
-
-        String key = String.format("testId:%s:problemNumber:%s:language:%s", testId, problemNumber, language);
-
-        return new ResponseEntity<>(tempCodeService.getTempCode(key), HttpStatus.OK);
-
     }
 }

--- a/src/main/java/swm_nm/morandi/domain/testDuring/dto/InputData.java
+++ b/src/main/java/swm_nm/morandi/domain/testDuring/dto/InputData.java
@@ -10,6 +10,8 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 public class InputData {
+    private Long testId;
+    private Long problemNumber;
     private String language;
     private String code;
     private String input;

--- a/src/main/java/swm_nm/morandi/domain/testDuring/dto/TempCode.java
+++ b/src/main/java/swm_nm/morandi/domain/testDuring/dto/TempCode.java
@@ -5,15 +5,15 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
 @NoArgsConstructor
 @Builder
 @AllArgsConstructor
+@Getter
+@Setter
 public class TempCode {
 
     public void setCode(String code) {

--- a/src/main/java/swm_nm/morandi/domain/testDuring/dto/TestInputData.java
+++ b/src/main/java/swm_nm/morandi/domain/testDuring/dto/TestInputData.java
@@ -9,6 +9,8 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 public class TestInputData {
+    private Long testId;
+    private Long problemNumber;
     private String language;
     private String code;
     private List<String> input;

--- a/src/main/java/swm_nm/morandi/domain/testDuring/service/RunCodeService.java
+++ b/src/main/java/swm_nm/morandi/domain/testDuring/service/RunCodeService.java
@@ -22,6 +22,8 @@ import java.util.List;
 @Slf4j
 public class RunCodeService {
 
+    private final TempCodeService tempCodeService;
+
     @Value("${compile.url}")
     public String url;
 
@@ -29,6 +31,9 @@ public class RunCodeService {
     public String tcUrl;
 
     public OutputDto runCode(InputData inputData) throws Exception {
+
+        tempCodeService.saveTempCode(inputData.getTestId(), inputData.getProblemNumber(),
+                inputData.getLanguage(), inputData.getCode());
 
         CloseableHttpClient httpClient = HttpClients.createDefault();
 
@@ -54,6 +59,9 @@ public class RunCodeService {
         }
     }
     public List<OutputDto> runTestCaseCode(TestInputData testInputData) throws Exception {
+
+        tempCodeService.saveTempCode(testInputData.getTestId(),
+                testInputData.getProblemNumber(), testInputData.getLanguage(), testInputData.getCode());
 
         CloseableHttpClient httpClient = HttpClients.createDefault();
 

--- a/src/main/java/swm_nm/morandi/domain/testExit/controller/TestExitController.java
+++ b/src/main/java/swm_nm/morandi/domain/testExit/controller/TestExitController.java
@@ -11,7 +11,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import swm_nm.morandi.domain.testDuring.dto.TestCheckDto;
 import swm_nm.morandi.domain.testExit.dto.AttemptCodeDto;
-import swm_nm.morandi.domain.testExit.dto.AttemptProblemDto;
 import swm_nm.morandi.domain.testExit.dto.TestResultDto;
 import swm_nm.morandi.domain.testExit.service.SaveCodeService;
 import swm_nm.morandi.domain.testExit.service.TestExitService;

--- a/src/main/java/swm_nm/morandi/domain/testStart/dto/TestCodeDto.java
+++ b/src/main/java/swm_nm/morandi/domain/testStart/dto/TestCodeDto.java
@@ -1,0 +1,15 @@
+package swm_nm.morandi.domain.testStart.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TestCodeDto {
+    private Long problemNumber;
+    private String pythonCode;
+    private String cppCode;
+    private String javaCode;
+}

--- a/src/main/java/swm_nm/morandi/domain/testStart/dto/TestStartResponseDto.java
+++ b/src/main/java/swm_nm/morandi/domain/testStart/dto/TestStartResponseDto.java
@@ -12,5 +12,6 @@ import java.util.List;
 public class TestStartResponseDto {
     private Long testId;
     private List<Long> bojProblemIds = new ArrayList<>();
+    private List<TestCodeDto> testCodeDtos = new ArrayList<>();
     private Long remainingTime;
 }


### PR DESCRIPTION
본래 테스트가 시작할 때 기본 코드를 Redis에 저장하고 호출할 때 api가 따로 있었으나, 테스트를 시작할 때 (또는 재시작) 언어별 코드를 제공하고,
output api를 호출했을 때 코드를 저장하도록 한다.