### PR TITLE
[FIX] 사용자의 현재 레이팅 반영 오류 수정 

### DIFF
--- a/src/main/java/swm_nm/morandi/domain/testExit/service/TestExitService.java
+++ b/src/main/java/swm_nm/morandi/domain/testExit/service/TestExitService.java
@@ -100,6 +100,7 @@ public class TestExitService {
         testResultDto.setBeforeRating(member.getRating());
         testResultDto.setAfterRating(test.getTestRating());
         testResultDto.setTestDate(test.getTestDate());
+        member.setRating(test.getTestRating());
 
         // 테스트 결과 저장
         testTypeRepository.save(testType);


### PR DESCRIPTION
테스트가 끝난 후에 결과 레이팅이 사용자 레이팅에 반영되어야 하는데 반영되지 못한 오류를 해결한다.
