### PR TITLE
:pencil2: [FIX] 최근 테스트 기록을 페이지 형태로 수정

### DIFF
--- a/src/main/java/swm_nm/morandi/domain/member/dto/MemberListRequestDto.java
+++ b/src/main/java/swm_nm/morandi/domain/member/dto/MemberListRequestDto.java
@@ -7,6 +7,6 @@ import lombok.Setter;
 @Getter @Setter
 @RequiredArgsConstructor
 public class MemberListRequestDto {
-    private Integer page;
-    private Integer size;
+    private Integer page = 1;
+    private Integer size = 15;
 }

--- a/src/main/java/swm_nm/morandi/domain/testInfo/controller/TestInfoController.java
+++ b/src/main/java/swm_nm/morandi/domain/testInfo/controller/TestInfoController.java
@@ -2,12 +2,14 @@ package swm_nm.morandi.domain.testInfo.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.jaxb.SpringDataJaxb;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import swm_nm.morandi.domain.testRecord.dto.TestRecordDto;
 import swm_nm.morandi.domain.testInfo.dto.TestTypeDto;
 import swm_nm.morandi.domain.testInfo.service.*;
+import swm_nm.morandi.domain.testRecord.dto.TestRecordRequestDto;
 
 import java.util.List;
 
@@ -28,8 +30,8 @@ public class TestInfoController {
     private final TestTypeInfoService testTypeInfoService;
     @GetMapping("/latest")
     @Operation(summary = "최근에 본 테스트 목록", description = "마이 페이지에서 최근에 본 테스트 4개를 제공합니다.")
-    public ResponseEntity<List<TestRecordDto>> getLatestTestDtos() {
-        return new ResponseEntity<>(latestTestInfoService.getTestRecordDtosLatest(), HttpStatus.OK);
+    public ResponseEntity<List<TestRecordDto>> getLatestTestDtos(TestRecordRequestDto testRecordRequestDto) {
+        return new ResponseEntity<>(latestTestInfoService.getTestRecordDtosLatest(testRecordRequestDto), HttpStatus.OK);
     }
     @GetMapping("/practice")
     @Operation(summary = "연습 테스트 목록", description = "메인 페이지에서 현재 있는 연습 테스트 정보를 제공합니다.")

--- a/src/main/java/swm_nm/morandi/domain/testInfo/service/LatestTestInfoService.java
+++ b/src/main/java/swm_nm/morandi/domain/testInfo/service/LatestTestInfoService.java
@@ -13,6 +13,7 @@ import swm_nm.morandi.domain.testExit.dto.AttemptProblemDto;
 import swm_nm.morandi.domain.testInfo.entity.AttemptProblem;
 import swm_nm.morandi.domain.testRecord.dto.TestRecordDto;
 import swm_nm.morandi.domain.testInfo.entity.Tests;
+import swm_nm.morandi.domain.testRecord.dto.TestRecordRequestDto;
 import swm_nm.morandi.domain.testRecord.mapper.TestRecordMapper;
 import swm_nm.morandi.domain.testInfo.repository.TestRepository;
 import swm_nm.morandi.domain.testRecord.repository.AttemptProblemRepository;
@@ -33,10 +34,12 @@ public class LatestTestInfoService {
     private final AttemptProblemRepository attemptProblemRepository;
 
     @Transactional
-    public List<TestRecordDto> getTestRecordDtosLatest() {
+    public List<TestRecordDto> getTestRecordDtosLatest(TestRecordRequestDto testRecordRequestDto) {
         Long memberId = SecurityUtils.getCurrentMemberId();
+        Integer page = testRecordRequestDto.getPage();
+        Integer size = testRecordRequestDto.getSize();
         //페이징하여 최근 4개의 테스트 기록을 가져옴
-        Pageable pageable = PageRequest.of(0, 4, Sort.by(DESC, "testDate"));
+        Pageable pageable = PageRequest.of(page - 1, size, Sort.by(DESC, "testDate"));
         List<Tests> recentTests = testRepository.findAllTestsByMember_MemberIdAndTestStatus(memberId, TestStatus.COMPLETED, pageable);
 
         //테스트 기록을 받아와서 dto로 변환하면서 getAttemptProblemDtos를 통해 테스트 문제들을 dto로 변환

--- a/src/main/java/swm_nm/morandi/domain/testRecord/dto/TestRecordRequestDto.java
+++ b/src/main/java/swm_nm/morandi/domain/testRecord/dto/TestRecordRequestDto.java
@@ -1,0 +1,14 @@
+package swm_nm.morandi.domain.testRecord.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+public class TestRecordRequestDto {
+    private Integer page = 1;
+    private Integer size = 4;
+}


### PR DESCRIPTION
본래 첫 페이지의 4개의 최근 테스트 기록만 제공하던 것을 클라이언트에서 원하는 페이지를 선택할 수 있도록 수정한다.