### PR TITLE
[FIX] 시험 결과의 정답 시간 반환값 변경

### DIFF
--- a/src/main/java/swm_nm/morandi/domain/testExit/dto/AttemptProblemDto.java
+++ b/src/main/java/swm_nm/morandi/domain/testExit/dto/AttemptProblemDto.java
@@ -11,13 +11,16 @@ public class AttemptProblemDto {
     private Long testProblemId;
     private Long bojProblemId;
     private Boolean isSolved;
-    private Long executionTime;
+    private String executionTime;
 
     public static AttemptProblemDto getAttemptProblemDto(AttemptProblem attemptProblem) {
+        Long attemptProblemExecutionTime = attemptProblem.getExecutionTime();
+        String executionTime = (attemptProblemExecutionTime == null)
+                ? null : String.format("%d:%02d", attemptProblemExecutionTime / 60, attemptProblemExecutionTime % 60);
         return AttemptProblemDto.builder()
                 .bojProblemId(attemptProblem.getProblem().getBojProblemId())
                 .isSolved(attemptProblem.getIsSolved())
-                .executionTime(attemptProblem.getExecutionTime())
+                .executionTime(executionTime)
                 .build();
     }
 }

--- a/src/main/java/swm_nm/morandi/domain/testInfo/controller/TestInfoController.java
+++ b/src/main/java/swm_nm/morandi/domain/testInfo/controller/TestInfoController.java
@@ -2,7 +2,6 @@ package swm_nm.morandi.domain.testInfo.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.jaxb.SpringDataJaxb;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;


### PR DESCRIPTION
본래 맞춘 시간을 분 단위로 반환했으나 이를 hh:mm 형태로 반환하여 사용자가 알아볼 수 있도록 수정한다.