### PR TITLE
[FEAT] 시험 중 정보 Redis로 유지하기

### DIFF
--- a/src/main/java/swm_nm/morandi/config/configuration/InitialCodeConfig.java
+++ b/src/main/java/swm_nm/morandi/config/configuration/InitialCodeConfig.java
@@ -1,0 +1,44 @@
+package swm_nm.morandi.config.configuration;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+import swm_nm.morandi.domain.common.Language;
+import swm_nm.morandi.domain.testDuring.dto.TempCodeDto;
+
+import javax.annotation.PostConstruct;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.HashMap;
+
+@Configuration
+@Getter
+@Slf4j
+public class InitialCodeConfig {
+
+    private HashMap<Language, String> initialCode;
+
+    @PostConstruct
+    public void initialize(){
+        initialCode = new HashMap<>();
+        String pythonCode = readCodeFromFile("codes/temp.py");
+        String cppCode = readCodeFromFile("codes/temp.cpp");
+        String javaCode = readCodeFromFile("codes/temp.java");
+        initialCode.put(Language.Python, pythonCode);
+        initialCode.put(Language.Cpp, cppCode);
+        initialCode.put(Language.Java, javaCode);
+    }
+
+
+    private String readCodeFromFile(String filePath) {
+        try {
+            return new String(Files.readAllBytes(Paths.get(filePath)));
+        } catch (IOException e) {
+            log.error("Error reading code from file: " + filePath, e);
+            return "";
+        }
+    }
+
+
+}

--- a/src/main/java/swm_nm/morandi/domain/codeSubmit/dto/SubmitCodeDto.java
+++ b/src/main/java/swm_nm/morandi/domain/codeSubmit/dto/SubmitCodeDto.java
@@ -4,6 +4,7 @@ package swm_nm.morandi.domain.codeSubmit.dto;
 import lombok.Getter;
 import lombok.Setter;
 import swm_nm.morandi.domain.codeSubmit.constants.SubmitConstants;
+import swm_nm.morandi.domain.common.Language;
 import swm_nm.morandi.global.exception.MorandiException;
 import swm_nm.morandi.global.exception.errorcode.SubmitErrorCode;
 
@@ -17,14 +18,16 @@ public class SubmitCodeDto {
     public String bojProblemId;
 
     @NotNull(message = "언어를 입력해주세요")
-    public String language;
+    public Language language;
+
+    public Integer problemNumber;
 
     @NotNull(message = "소스코드를 입력해주세요")
     public String sourceCode;
 
     public String getLanguageId() {
         try {
-            return SubmitConstants.valueOf(this.language).getLanguageId();
+            return SubmitConstants.valueOf(this.language.getLanguage()).getLanguageId();
         } catch (IllegalArgumentException e) {
             throw new MorandiException(SubmitErrorCode.LANGUAGE_CODE_NOT_FOUND);
         }

--- a/src/main/java/swm_nm/morandi/domain/common/Language.java
+++ b/src/main/java/swm_nm/morandi/domain/common/Language.java
@@ -1,0 +1,18 @@
+package swm_nm.morandi.domain.common;
+
+public enum Language {
+    Python("Python"),
+    Java("Java"),
+    Cpp("Cpp");
+
+    private String language;
+
+    Language(String language) {
+        this.language = language;
+    }
+
+    public String getLanguage() {
+        return language;
+    }
+
+}

--- a/src/main/java/swm_nm/morandi/domain/testDuring/dto/InputData.java
+++ b/src/main/java/swm_nm/morandi/domain/testDuring/dto/InputData.java
@@ -1,6 +1,7 @@
 package swm_nm.morandi.domain.testDuring.dto;
 
 import lombok.*;
+import swm_nm.morandi.domain.common.Language;
 
 import java.util.List;
 
@@ -11,8 +12,8 @@ import java.util.List;
 @Builder
 public class InputData {
     private Long testId;
-    private Long problemNumber;
-    private String language;
+    private Integer problemNumber;
+    private Language language;
     private String code;
     private String input;
 }

--- a/src/main/java/swm_nm/morandi/domain/testDuring/dto/TempCodeDto.java
+++ b/src/main/java/swm_nm/morandi/domain/testDuring/dto/TempCodeDto.java
@@ -1,16 +1,34 @@
 package swm_nm.morandi.domain.testDuring.dto;
 
-
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import swm_nm.morandi.domain.common.Language;
 
+
+@Builder
 @Getter
-@Setter
+@Slf4j
+@AllArgsConstructor
 @NoArgsConstructor
 public class TempCodeDto {
-    private String testId;
-    private String problemNumber;
-    private String language;
-    private String code;
+    private String pythonCode;
+    private String javaCode;
+    private String cppCode;
+
+    private Language lastAccessCode;
+
+    public void writeCode(String code, Language language) {
+        switch (language) {
+            case Python -> this.pythonCode = code;
+            case Cpp -> this.cppCode = code;
+            case Java -> this.javaCode = code;
+        }
+        log.error("writeCode"+code);
+        this.lastAccessCode = language;
+    }
+
+
 }

--- a/src/main/java/swm_nm/morandi/domain/testDuring/dto/TestInfo.java
+++ b/src/main/java/swm_nm/morandi/domain/testDuring/dto/TestInfo.java
@@ -14,13 +14,9 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Getter
 @Setter
-public class TempCode {
+public class TestInfo {
 
-    public void setCode(String code) {
-        this.code = code;
-    }
-
-    public String code;
+    public Long testId;
 
     @JsonSerialize(using = LocalDateTimeSerializer.class)
     @JsonDeserialize(using = LocalDateTimeDeserializer.class)

--- a/src/main/java/swm_nm/morandi/domain/testDuring/dto/TestInputData.java
+++ b/src/main/java/swm_nm/morandi/domain/testDuring/dto/TestInputData.java
@@ -1,6 +1,7 @@
 package swm_nm.morandi.domain.testDuring.dto;
 
 import lombok.*;
+import swm_nm.morandi.domain.common.Language;
 
 import java.util.List;
 
@@ -10,8 +11,8 @@ import java.util.List;
 @Builder
 public class TestInputData {
     private Long testId;
-    private Long problemNumber;
-    private String language;
+    private Integer problemNumber;
+    private Language language;
     private String code;
     private List<String> input;
     private List<String> output;

--- a/src/main/java/swm_nm/morandi/domain/testDuring/dto/factory/TempCodeFactory.java
+++ b/src/main/java/swm_nm/morandi/domain/testDuring/dto/factory/TempCodeFactory.java
@@ -1,0 +1,26 @@
+package swm_nm.morandi.domain.testDuring.dto.factory;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import swm_nm.morandi.config.configuration.InitialCodeConfig;
+import swm_nm.morandi.domain.common.Language;
+import swm_nm.morandi.domain.testDuring.dto.TempCodeDto;
+
+import java.util.HashMap;
+
+@Service
+@RequiredArgsConstructor
+public class TempCodeFactory {
+    private final InitialCodeConfig initialCodeConfig;
+
+    public TempCodeDto getTempCodeDto() {
+        HashMap<Language, String> initialCode = initialCodeConfig.getInitialCode();
+
+        return TempCodeDto.builder()
+                .pythonCode(initialCode.get(Language.Python))
+                .cppCode(initialCode.get(Language.Cpp))
+                .javaCode(initialCode.get(Language.Java))
+                .lastAccessCode(Language.Cpp)
+                .build();
+    }
+}

--- a/src/main/java/swm_nm/morandi/domain/testExit/service/TestExitService.java
+++ b/src/main/java/swm_nm/morandi/domain/testExit/service/TestExitService.java
@@ -2,6 +2,7 @@ package swm_nm.morandi.domain.testExit.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import swm_nm.morandi.domain.testDuring.dto.TestCheckDto;
 import swm_nm.morandi.domain.testDuring.dto.TestStatus;
@@ -21,6 +22,7 @@ import swm_nm.morandi.global.exception.errorcode.AuthErrorCode;
 import swm_nm.morandi.global.exception.errorcode.TestErrorCode;
 import swm_nm.morandi.global.exception.errorcode.TestTypeErrorCode;
 import swm_nm.morandi.global.utils.SecurityUtils;
+import swm_nm.morandi.redis.utils.RedisKeyGenerator;
 
 import javax.transaction.Transactional;
 import java.util.ArrayList;
@@ -44,6 +46,9 @@ public class TestExitService {
     private final CalculateRatingService calculateRatingService;
 
     private final SolvedCheckService solvedCheckService;
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final RedisKeyGenerator redisKeyGenerator;
 
     //Controller에서 사용되는 것
     public TestResultDto testExit(TestCheckDto testCheckDto)
@@ -78,6 +83,7 @@ public class TestExitService {
 
         testResultDto.setAttemptProblemDtos(attemptProblemDtos);
 
+        redisTemplate.delete(redisKeyGenerator.generateOngoingTestKey());
         return testResultDto;
     }
 

--- a/src/main/java/swm_nm/morandi/domain/testRecord/repository/AttemptProblemRepository.java
+++ b/src/main/java/swm_nm/morandi/domain/testRecord/repository/AttemptProblemRepository.java
@@ -17,6 +17,9 @@ public interface AttemptProblemRepository extends JpaRepository<AttemptProblem, 
     List<AttemptProblem> findAllByTest_TestId(Long testId);
     List<AttemptProblem> findAllByTestOrderByAttemptProblemIdAsc(Tests test);
 
+
+    @EntityGraph(attributePaths = {"test", "problem"})
+    Optional<AttemptProblem> findByTest_TestIdAndProblem_BojProblemId(Long testId, Long bojProblemId);
     @EntityGraph(attributePaths = {"test", "problem"})
     Optional<AttemptProblem> findByMember_MemberIdAndTest_testIdAndTest_TestStatusAndProblem_BojProblemId(Long memberId, Long testId, TestStatus testStatus, Long bojProblemId);
     List<AttemptProblem> findAttemptProblemsByTest_TestId(Long testId);

--- a/src/main/java/swm_nm/morandi/domain/testStart/dto/TestCodeDto.java
+++ b/src/main/java/swm_nm/morandi/domain/testStart/dto/TestCodeDto.java
@@ -8,7 +8,7 @@ import lombok.*;
 @AllArgsConstructor
 @Builder
 public class TestCodeDto {
-    private Long problemNumber;
+    private Integer problemNumber;
     private String pythonCode;
     private String cppCode;
     private String javaCode;

--- a/src/main/java/swm_nm/morandi/domain/testStart/service/AddTestService.java
+++ b/src/main/java/swm_nm/morandi/domain/testStart/service/AddTestService.java
@@ -2,7 +2,10 @@ package swm_nm.morandi.domain.testStart.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
+import swm_nm.morandi.domain.testDuring.dto.TempCodeDto;
 import swm_nm.morandi.domain.testDuring.dto.TestCheckDto;
 import swm_nm.morandi.domain.testDuring.dto.TestStatus;
 import swm_nm.morandi.domain.testInfo.entity.TestType;
@@ -22,6 +25,10 @@ public class AddTestService {
     private final TestRepository testRepository;
 
     private final TestScheduler testScheduler;
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+
     @Transactional
     public Tests startTestByTestTypeId(TestType testType, Member member) {
         Tests test = Tests.builder()
@@ -45,9 +52,22 @@ public class AddTestService {
                 .bojId(member.getBojId())
                 .build();
 
-        testScheduler.addTest(testCheckDto);
-        member.setCurrentTestId(testId);
+        //testScheduler.addTest(testCheckDto);
+
 
         return test;
     }
+
+    public String generateTestKdy(Long testId) {
+        return "test:" + testId;
+    }
+
+
+    public void initializeTempCode(){
+        HashOperations<String, String, TempCodeDto> hashOps = redisTemplate.opsForHash();
+
+
+
+    }
+
 }

--- a/src/main/java/swm_nm/morandi/domain/testStart/service/TestProgressCheckService.java
+++ b/src/main/java/swm_nm/morandi/domain/testStart/service/TestProgressCheckService.java
@@ -1,9 +1,11 @@
 package swm_nm.morandi.domain.testStart.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import swm_nm.morandi.domain.member.entity.Member;
 import swm_nm.morandi.domain.testDuring.dto.TestCheckDto;
+import swm_nm.morandi.domain.testDuring.dto.TestInfo;
 import swm_nm.morandi.domain.testInfo.entity.TestType;
 import swm_nm.morandi.domain.testInfo.entity.Tests;
 import swm_nm.morandi.domain.testExit.service.TestExitService;
@@ -12,6 +14,7 @@ import swm_nm.morandi.domain.testInfo.repository.TestTypeRepository;
 import swm_nm.morandi.global.exception.MorandiException;
 import swm_nm.morandi.global.exception.errorcode.TestErrorCode;
 import swm_nm.morandi.global.exception.errorcode.TestTypeErrorCode;
+import swm_nm.morandi.redis.utils.RedisKeyGenerator;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -23,13 +26,14 @@ public class TestProgressCheckService {
     private final TestRepository testRepository;
     private final TestTypeRepository testTypeRepository;
     private final TestExitService testExitService;
-
-    private void extracted(Tests test) {
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final RedisKeyGenerator redisKeyGenerator;
+    private void setRemainingTestTime(Tests test) {
         Duration duration = Duration.between(test.getTestDate(), LocalDateTime.now());
         test.setRemainingTime(test.getTestTime() * 60 - duration.getSeconds());
     }
 
-    private void extracted(TestType testType, Member member, Tests test) {
+    private void testExit(TestType testType, Member member, Tests test) {
         TestCheckDto testCheckDto = TestCheckDto.builder()
                 .testId(test.getTestId())
                 .bojId(member.getBojId())
@@ -39,27 +43,29 @@ public class TestProgressCheckService {
 
     //TODO Redis 이용하여
     // 현재 테스트가 진행중인지 확인하도록
-    public Tests isTestinProgress(Member member){
-        if (member.getCurrentTestId() == null)
-            member.setCurrentTestId(-1L);
+    public Tests getOngoingTest(Member member){
 
-        // 현재 테스트가 진행중이라면
-        if (member.getCurrentTestId() != -1L) {
-            Long currentTestId = member.getCurrentTestId();
-            Tests test = testRepository.findById(currentTestId).orElseThrow(() -> new MorandiException(TestErrorCode.TEST_NOT_FOUND));
+        // 현재 테스트가 진행중이 아니라면
+        String ongoingTestKey = redisKeyGenerator.generateOngoingTestKey();
+        TestInfo testInfo = (TestInfo) redisTemplate.opsForValue().get(ongoingTestKey);
 
-            // 테스트 시작 시간과 현재 시간을 비교하여 남은 시간 계산
-            extracted(test);
-
-            if (test.getRemainingTime() > 0) { // 시간이 남았을경우 진행중인 테스트 반환
-                return test; //getTestStartResponseDto(currentTestId, test);
-            }
-            else { // 시간이 마감된 테스트 종료
-                TestType testType = testTypeRepository.findTestTypeByTestTypename(test.getTestTypename())
-                        .orElseThrow(() -> new MorandiException(TestTypeErrorCode.TEST_TYPE_NOT_FOUND));
-                extracted(testType, member, test);
-            }
+        if(testInfo==null) {
+            return null;
         }
-        return null;
+        //만약 종료시간이 현재 시간을 지났으면? -> 테스트 종료 후 없다고 반환 후 redis 캐시 삭제
+        if(testInfo.endTime.isBefore(LocalDateTime.now())) {
+            Tests test = testRepository.findById(testInfo.getTestId()).orElseThrow(() -> new MorandiException(TestErrorCode.TEST_NOT_FOUND));
+            TestType testType = testTypeRepository.findTestTypeByTestTypename(test.getTestTypename())
+                    .orElseThrow(() -> new MorandiException(TestTypeErrorCode.TEST_TYPE_NOT_FOUND));
+            testExit(testType, member, test);
+
+            return null;
+        }
+        else {
+            Tests test = testRepository.findById(testInfo.getTestId()).orElseThrow(() -> new MorandiException(TestErrorCode.TEST_NOT_FOUND));
+            setRemainingTestTime(test);
+            return test;
+        }
+
     }
 }

--- a/src/main/java/swm_nm/morandi/global/exception/errorcode/SubmitErrorCode.java
+++ b/src/main/java/swm_nm/morandi/global/exception/errorcode/SubmitErrorCode.java
@@ -15,7 +15,8 @@ public enum SubmitErrorCode implements ErrorCode {
     BAEKJOON_UNKNOWN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"알 수 없는 오류가 발생했습니다"),
     INVALID_BOJPROBLEM_NUMBER(HttpStatus.BAD_REQUEST,"유효하지 않은 문제 번호입니다"),
     CANT_FIND_SOLUTION_ID(HttpStatus.BAD_REQUEST,"Solution ID를 찾을 수 없습니다"),
-    NULL_POINTER_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR,"백준 Response NullPointerException")
+    NULL_POINTER_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR,"백준 Response NullPointerException"),
+    TEST_NOT_EXIST(HttpStatus.BAD_REQUEST,"저장하려는 문제의 테스트가 존재하지 않습니다")
     ;
 
     //TODO

--- a/src/main/java/swm_nm/morandi/redis/config/RedisConfig.java
+++ b/src/main/java/swm_nm/morandi/redis/config/RedisConfig.java
@@ -1,4 +1,4 @@
-package swm_nm.morandi.domain.testDuring.config;
+package swm_nm.morandi.redis.config;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -22,6 +22,13 @@ public class RedisConfig {
         template.setConnectionFactory(redisConnectionFactory);
         template.setKeySerializer(new StringRedisSerializer());
         template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        // Hash Key Serializer
+        template.setHashKeySerializer(new StringRedisSerializer());
+
+        // Hash Value Serializer
+        template.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
+
         return template;
     }
 }

--- a/src/main/java/swm_nm/morandi/redis/utils/RedisKeyGenerator.java
+++ b/src/main/java/swm_nm/morandi/redis/utils/RedisKeyGenerator.java
@@ -1,0 +1,17 @@
+package swm_nm.morandi.redis.utils;
+
+
+import org.springframework.stereotype.Component;
+import swm_nm.morandi.global.utils.SecurityUtils;
+
+@Component
+public class RedisKeyGenerator {
+    public String generateOngoingTestKey() {
+        return String.format("testing:memberId:%s", SecurityUtils.getCurrentMemberId());
+    }
+    public String generateTempCodeKey(Long testId) {
+
+        return String.format("testId:%s", testId);
+    }
+
+}


### PR DESCRIPTION
- 기존 Member 엔티티의 필드로 진행중인 테스트를 실행하던 것을 Redis로 관리하며 Redis 관련 코드를 리팩토링한다.